### PR TITLE
Made more customizable native libraries loading.

### DIFF
--- a/src/java/org/jnativehook/DefaultNativeLibraryLoader.java
+++ b/src/java/org/jnativehook/DefaultNativeLibraryLoader.java
@@ -1,0 +1,174 @@
+package org.jnativehook;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.math.BigInteger;
+import java.net.URL;
+import java.security.DigestInputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.jar.Attributes;
+import java.util.jar.JarInputStream;
+import java.util.jar.Manifest;
+import java.util.logging.Logger;
+
+public class DefaultNativeLibraryLoader implements NativeLibraryLoader {
+
+	private static Logger LOG = Logger
+			.getLogger(DefaultNativeLibraryLoader.class.getPackage().getName());
+
+	/**
+	 * Perform default procedures to interface with the native library. These
+	 * procedures include unpacking and loading the library into the Java
+	 * Virtual Machine.
+	 */
+	public void load() {
+		String libName = System.getProperty("jnativehook.lib.name",
+				"JNativeHook");
+
+		try {
+			// Try to load the native library assuming the java.library.path was
+			// set correctly at launch.
+			System.loadLibrary(libName);
+		} catch (UnsatisfiedLinkError linkError) {
+			// Get the package name for the GlobalScreen.
+			String basePackage = GlobalScreen.class.getPackage().getName()
+					.replace('.', '/');
+
+			// Compile the resource path for the
+			StringBuilder libResourcePath = new StringBuilder("/");
+			libResourcePath.append(basePackage).append("/lib/");
+			libResourcePath.append(NativeSystem.getFamily()).append('/');
+			libResourcePath.append(NativeSystem.getArchitecture()).append('/');
+
+			// Get what the system "thinks" the library name should be.
+			String libNativeName = System.mapLibraryName(libName);
+
+			// Hack for OS X JRE 1.6 and earlier.
+			libNativeName = libNativeName.replaceAll("\\.jnilib$", "\\.dylib");
+
+			// Slice up the library name.
+			int i = libNativeName.lastIndexOf('.');
+			String libNativePrefix = libNativeName.substring(0, i) + '-';
+			String libNativeSuffix = libNativeName.substring(i);
+			String libNativeVersion = null;
+
+			// This may return null in some circumstances.
+			InputStream libInputStream = GlobalScreen.class
+					.getResourceAsStream(libResourcePath.toString()
+							.toLowerCase() + libNativeName);
+			if (libInputStream != null) {
+				try {
+					// Try and load the Jar manifest as a resource stream.
+					URL jarFile = GlobalScreen.class.getProtectionDomain()
+							.getCodeSource().getLocation();
+					JarInputStream jarInputStream = new JarInputStream(
+							jarFile.openStream());
+
+					// Try and extract a version string from the Manifest.
+					Manifest manifest = jarInputStream.getManifest();
+					if (manifest != null) {
+						Attributes attributes = manifest
+								.getAttributes(basePackage);
+
+						if (attributes != null) {
+							String version = attributes
+									.getValue("Specification-Version");
+							String revision = attributes
+									.getValue("Implementation-Version");
+
+							libNativeVersion = version + '.' + revision;
+						} else {
+							Logger.getLogger(
+									GlobalScreen.class.getPackage().getName())
+									.warning("Invalid library manifest!\n");
+						}
+					} else {
+						Logger.getLogger(
+								GlobalScreen.class.getPackage().getName())
+								.warning("Cannot find library manifest!\n");
+					}
+
+					jarInputStream.close();
+				} catch (IOException e) {
+					LOG.severe(e.getMessage());
+				}
+				try {
+					// The temp file for this instance of the library.
+					File libFile;
+
+					// If we were unable to extract a library version from the manifest.
+					if (libNativeVersion != null) {
+						libFile = new File(
+								System.getProperty("java.io.tmpdir"),
+								libNativePrefix + libNativeVersion
+										+ libNativeSuffix);
+					} else {
+						libFile = File.createTempFile(libNativePrefix,
+								libNativeSuffix);
+					}
+
+					byte[] buffer = new byte[4 * 1024];
+					int size;
+
+					// Check and see if a copy of the native lib already exists.
+					FileOutputStream libOutputStream = new FileOutputStream(
+							libFile);
+
+					// Setup a digest...
+					MessageDigest sha1 = MessageDigest.getInstance("SHA-1");
+					DigestInputStream digestInputStream = new DigestInputStream(
+							libInputStream, sha1);
+
+					// Read from the digest stream and write to the file steam.
+					while ((size = digestInputStream.read(buffer)) != -1) {
+						libOutputStream.write(buffer, 0, size);
+					}
+
+					// Close all the streams.
+					digestInputStream.close();
+					libInputStream.close();
+					libOutputStream.close();
+
+					// Convert the digest from byte[] to hex string.
+					String sha1Sum = new BigInteger(1, sha1.digest()).toString(
+							16).toUpperCase();
+					if (libNativeVersion == null) {
+						// Use the sha1 sum as a version finger print.
+						libNativeVersion = sha1Sum;
+
+						// Better late than never.
+						File newFile = new File(
+								System.getProperty("java.io.tmpdir"),
+								libNativePrefix + libNativeVersion
+										+ libNativeSuffix);
+						if (libFile.renameTo(newFile)) {
+							libFile = newFile;
+						}
+					}
+
+					// Set the library version property.
+					System.setProperty("jnativehook.lib.version",
+							libNativeVersion);
+
+					// Load the native library.
+					System.load(libFile.getPath());
+
+					LOG.info("Library extracted successfully: "
+							+ libFile.getPath() + " (0x" + sha1Sum + ").\n");
+				} catch (IOException e) {
+					throw new IllegalStateException(e.getMessage(), e);
+				} catch (NoSuchAlgorithmException e) {
+					throw new IllegalStateException(e.getMessage(), e);
+				}
+			} else {
+				LOG.severe("Unable to extract the native library "
+						+ libResourcePath.toString().toLowerCase()
+						+ libNativeName + "!\n");
+				throw new UnsatisfiedLinkError();
+			}
+		}
+	}
+}

--- a/src/java/org/jnativehook/GlobalScreen.java
+++ b/src/java/org/jnativehook/GlobalScreen.java
@@ -26,22 +26,9 @@ import org.jnativehook.mouse.NativeMouseMotionListener;
 import org.jnativehook.mouse.NativeMouseWheelEvent;
 import org.jnativehook.mouse.NativeMouseWheelListener;
 import javax.swing.event.EventListenerList;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.math.BigInteger;
-import java.net.URL;
-import java.security.DigestInputStream;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
-import java.util.jar.Attributes;
-import java.util.jar.JarInputStream;
-import java.util.jar.Manifest;
-import java.util.logging.Logger;
 
 /**
  * GlobalScreen is used to represent the native screen area that Java does not
@@ -58,15 +45,24 @@ import java.util.logging.Logger;
  * @version 1.2
  */
 public class GlobalScreen {
+	
 	/**
 	 * The GlobalScreen singleton.
 	 */
-	private static final GlobalScreen instance = new GlobalScreen();
+	private static GlobalScreen instance;
+
+	/**
+	 * The custom native library loader variable. By default uses old 
+	 * load style. If it is null do nothing. User can set it before use 
+	 * to have custom libraries load style.
+	 */
+	private static NativeLibraryLoader nativeLibraryLoader = 
+			new DefaultNativeLibraryLoader();
 
 	/**
 	 * The list of event listeners to notify.
 	 */
-	private static final EventListenerList eventListeners = new EventListenerList();
+	private final EventListenerList eventListeners = new EventListenerList();
 
 	/**
 	 * The service to control the hook.
@@ -84,8 +80,11 @@ public class GlobalScreen {
 	 * unpack and load the native library.
 	 */
 	private GlobalScreen() {
+
 		// Unpack and Load the native library.
-		GlobalScreen.loadNativeLibrary();
+		if (nativeLibraryLoader != null) {
+			nativeLibraryLoader.load(); 
+		}
 
 		eventExecutor = Executors.newSingleThreadExecutor(new ThreadFactory() {
 			public Thread newThread(Runnable r) {
@@ -119,6 +118,12 @@ public class GlobalScreen {
 
 		super.finalize();
 	}
+	
+	public static synchronized void setNativeLibraryLoader(NativeLibraryLoader 
+			nativeLibraryLoader) {
+		GlobalScreen.nativeLibraryLoader = nativeLibraryLoader;
+	}
+	
 
 	/**
 	 * Returns the singleton instance of <code>GlobalScreen</code>.
@@ -126,7 +131,14 @@ public class GlobalScreen {
 	 * @return singleton instance of <code>GlobalScreen</code>
 	 */
 	public static synchronized GlobalScreen getInstance() {
-		return GlobalScreen.instance;
+		
+		// Using lazy initialization to be able register custom native library 
+		// loader.
+		if (instance == null) {
+			instance = new GlobalScreen();
+		}
+		
+		return instance;
 	}
 
 
@@ -578,141 +590,5 @@ public class GlobalScreen {
 		}
 
 		GlobalScreen.eventExecutor = dispatcher;
-	}
-
-	/**
-	 * Perform procedures to interface with the native library. These procedures
-	 * include unpacking and loading the library into the Java Virtual Machine.
-	 */
-	private static void loadNativeLibrary() {
-		String libName = System.getProperty("jnativehook.lib.name", "JNativeHook");
-
-		try {
-			// Try to load the native library assuming the java.library.path was
-			// set correctly at launch.
-			System.loadLibrary(libName);
-		}
-		catch (UnsatisfiedLinkError linkError) {
-			// Get the package name for the GlobalScreen.
-			String basePackage = GlobalScreen.class.getPackage().getName().replace('.', '/');
-
-			// Compile the resource path for the
-			StringBuilder libResourcePath = new StringBuilder("/");
-			libResourcePath.append(basePackage).append("/lib/");
-			libResourcePath.append(NativeSystem.getFamily()).append('/');
-			libResourcePath.append(NativeSystem.getArchitecture()).append('/');
-
-
-			// Get what the system "thinks" the library name should be.
-			String libNativeName = System.mapLibraryName(libName);
-			// Hack for OS X JRE 1.6 and earlier.
-			libNativeName = libNativeName.replaceAll("\\.jnilib$", "\\.dylib");
-
-			// Slice up the library name.
-			int i = libNativeName.lastIndexOf('.');
-			String libNativePrefix = libNativeName.substring(0, i) + '-';
-			String libNativeSuffix = libNativeName.substring(i);
-			String libNativeVersion = null;
-
-			// This may return null in some circumstances.
-			InputStream libInputStream = GlobalScreen.class.getResourceAsStream(libResourcePath.toString().toLowerCase() + libNativeName);
-			if (libInputStream != null) {
-				try {
-					// Try and load the Jar manifest as a resource stream.
-					URL jarFile = GlobalScreen.class.getProtectionDomain().getCodeSource().getLocation();
-					JarInputStream jarInputStream = new JarInputStream(jarFile.openStream());
-
-					// Try and extract a version string from the Manifest.
-					Manifest manifest = jarInputStream.getManifest();
-					if (manifest != null) {
-						Attributes attributes = manifest.getAttributes(basePackage);
-
-						if (attributes != null) {
-							String version = attributes.getValue("Specification-Version");
-							String revision = attributes.getValue("Implementation-Version");
-
-							libNativeVersion = version + '.' + revision;
-						}
-						else {
-							Logger.getLogger(GlobalScreen.class.getPackage().getName()).warning("Invalid library manifest!\n");
-						}
-					}
-					else {
-						Logger.getLogger(GlobalScreen.class.getPackage().getName()).warning("Cannot find library manifest!\n");
-					}
-				}
-				catch (IOException e) {
-					Logger.getLogger(GlobalScreen.class.getPackage().getName()).severe(e.getMessage());
-				}
-
-
-				try {
-					// The temp file for this instance of the library.
-					File libFile;
-
-					// If we were unable to extract a library version from the manifest.
-					if (libNativeVersion != null) {
-						libFile = new File(System.getProperty("java.io.tmpdir"), libNativePrefix + libNativeVersion + libNativeSuffix);
-					}
-					else {
-						libFile = File.createTempFile(libNativePrefix, libNativeSuffix);
-					}
-
-					byte[] buffer = new byte[4 * 1024];
-					int size;
-
-					// Check and see if a copy of the native lib already exists.
-					FileOutputStream libOutputStream = new FileOutputStream(libFile);
-
-					// Setup a digest...
-					MessageDigest sha1 = MessageDigest.getInstance("SHA-1");
-					DigestInputStream digestInputStream = new DigestInputStream(libInputStream, sha1);
-
-					// Read from the digest stream and write to the file steam.
-					while ((size = digestInputStream.read(buffer)) != -1) {
-						libOutputStream.write(buffer, 0, size);
-					}
-
-					// Close all the streams.
-					digestInputStream.close();
-					libInputStream.close();
-					libOutputStream.close();
-
-					// Convert the digest from byte[] to hex string.
-					String sha1Sum = new BigInteger(1, sha1.digest()).toString(16).toUpperCase();
-					if (libNativeVersion == null) {
-						// Use the sha1 sum as a version finger print.
-						libNativeVersion = sha1Sum;
-
-						// Better late than never.
-						File newFile = new File(System.getProperty("java.io.tmpdir"), libNativePrefix + libNativeVersion + libNativeSuffix);
-						if (libFile.renameTo(newFile)) {
-							libFile = newFile;
-						}
-					}
-
-					// Set the library version property.
-					System.setProperty("jnativehook.lib.version", libNativeVersion);
-
-					// Load the native library.
-					System.load(libFile.getPath());
-
-					Logger.getLogger(GlobalScreen.class.getPackage().getName())
-							.info("Library extracted successfully: " + libFile.getPath() + " (0x" + sha1Sum + ").\n");
-				}
-				catch (IOException e) {
-					throw new RuntimeException(e.getMessage(), e);
-				}
-				catch (NoSuchAlgorithmException e) {
-					throw new RuntimeException(e.getMessage(), e);
-				}
-			}
-			else {
-				Logger.getLogger(GlobalScreen.class.getPackage().getName())
-						.severe("Unable to extract the native library " + libResourcePath.toString().toLowerCase() + libNativeName + "!\n");
-
-				throw new UnsatisfiedLinkError();
-			}
-		}
 	}
 }

--- a/src/java/org/jnativehook/NativeLibraryLoader.java
+++ b/src/java/org/jnativehook/NativeLibraryLoader.java
@@ -1,0 +1,14 @@
+package org.jnativehook;
+
+/**
+ * The Interface NativeLibraryLoader used to define custom way to load native library.
+ * It instance must to be registered to GlobalScreen before use GlobalScreen.getInstance(). 
+ */
+public interface NativeLibraryLoader {
+
+	/**
+	 * Perform procedures to interface with the native library. These procedures
+	 * include unpacking and loading the library into the Java Virtual Machine.
+	 */
+	public void load();
+}


### PR DESCRIPTION
This is small change which makes native libraries loading more customizable. It do not breaks old usage, but makes possibility to use custom native libraries loading before use JNnativeHook GlobalScreen. 
Unit tests showed the same results with and without this change on my computer(s).