### PR TITLE
README - Fix "Consuming Events" Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ application simply execute the jar file provided. Source code available at
 * [Working with Swing](https://github.com/kwhat/jnativehook/wiki/Swing)
 * [Logging and Console Output](https://github.com/kwhat/jnativehook/wiki/ConsoleOutput)
 * [Advanced Library Loading](https://github.com/kwhat/jnativehook/wiki/LibraryLoading)
-* [Consuming Events (Unsupported)](https://github.com/kwhat/jnativehook/wiki/ConsoleOutput)
+* [Consuming Events (Unsupported)](https://github.com/kwhat/jnativehook/wiki/ConsumingEvents)
 
 ## Additional Information
 Up to date source code and documentation available at:


### PR DESCRIPTION
Readme link for consuming events currently redirects to consoleoutput