### PR TITLE
Listener class refactorings for java 8

### DIFF
--- a/src/java/org/jnativehook/keyboard/NativeKeyAdapter.java
+++ b/src/java/org/jnativehook/keyboard/NativeKeyAdapter.java
@@ -21,21 +21,8 @@ package org.jnativehook.keyboard;
  * Adapter implementation of the NativeKeyListener interface.
  * The methods are empty so the super call is obsolete.
  * @author Johannes Boczek
- *
+ * @deprecated No need to extend this class, implement the {@code NativeKeyListener} interface instead
  * @since 2.1
  */
-public class NativeKeyAdapter implements NativeKeyListener {
-
-	public void nativeKeyTyped(NativeKeyEvent nativeEvent) {
-		// Do Nothing.
-	}
-
-	public void nativeKeyPressed(NativeKeyEvent nativeEvent) {
-		// Do Nothing.
-	}
-
-	public void nativeKeyReleased(NativeKeyEvent nativeEvent) {
-		// Do Nothing.
-	}
-
-}
+@Deprecated
+public class NativeKeyAdapter implements NativeKeyListener {}

--- a/src/java/org/jnativehook/keyboard/NativeKeyListener.java
+++ b/src/java/org/jnativehook/keyboard/NativeKeyListener.java
@@ -47,19 +47,19 @@ public interface NativeKeyListener extends EventListener {
 	 *
 	 * @since 1.1
 	 */
-	public void nativeKeyTyped(NativeKeyEvent nativeEvent);
+	default void nativeKeyTyped(NativeKeyEvent nativeEvent) {}
 
 	/**
 	 * Invoked when a key has been pressed.
 	 *
 	 * @param nativeEvent the native key event.
 	 */
-	public void nativeKeyPressed(NativeKeyEvent nativeEvent);
+	default void nativeKeyPressed(NativeKeyEvent nativeEvent) {}
 
 	/**
 	 * Invoked when a key has been released.
 	 *
 	 * @param nativeEvent the native key event.
 	 */
-	public void nativeKeyReleased(NativeKeyEvent nativeEvent);
+	default void nativeKeyReleased(NativeKeyEvent nativeEvent) {}
 }

--- a/src/java/org/jnativehook/keyboard/SwingKeyAdapter.java
+++ b/src/java/org/jnativehook/keyboard/SwingKeyAdapter.java
@@ -30,26 +30,32 @@ import java.awt.event.KeyListener;
  */
 public class SwingKeyAdapter extends AbstractSwingInputAdapter implements NativeKeyListener, KeyListener {
 
+	@Override
 	public void nativeKeyTyped(NativeKeyEvent nativeEvent) {
 		this.keyTyped(this.getJavaKeyEvent(nativeEvent));
 	}
 
+	@Override
 	public void nativeKeyPressed(NativeKeyEvent nativeEvent) {
 		this.keyPressed(this.getJavaKeyEvent(nativeEvent));
 	}
 
+	@Override
 	public void nativeKeyReleased(NativeKeyEvent nativeEvent) {
 		this.keyReleased(this.getJavaKeyEvent(nativeEvent));
 	}
 
+	@Override
 	public void keyTyped(KeyEvent keyEvent) {
 		// Do Nothing.
 	}
 
+	@Override
 	public void keyPressed(KeyEvent keyEvent) {
 		// Do Nothing.
 	}
 
+	@Override
 	public void keyReleased(KeyEvent keyEvent) {
 		// Do Nothing.
 	}

--- a/src/java/org/jnativehook/mouse/NativeMouseAdapter.java
+++ b/src/java/org/jnativehook/mouse/NativeMouseAdapter.java
@@ -21,20 +21,7 @@ package org.jnativehook.mouse;
  * Adapter implementation of the NativeMouseListener interface.
  * The methods are empty so the super call is obsolete.
  * @author Johannes Boczek
- *
+ * @deprecated No need to extend this class, implement the {@code NativeMouseListener} interface instead
  */
-public class NativeMouseAdapter implements NativeMouseListener {
-
-	public void nativeMouseClicked(NativeMouseEvent nativeEvent) {
-		// Do Nothing.
-	}
-
-	public void nativeMousePressed(NativeMouseEvent nativeEvent) {
-		// Do Nothing.
-	}
-
-	public void nativeMouseReleased(NativeMouseEvent nativeEvent) {
-		// Do Nothing.
-	}
-	
-}
+@Deprecated
+public class NativeMouseAdapter implements NativeMouseListener {}

--- a/src/java/org/jnativehook/mouse/NativeMouseInputAdapter.java
+++ b/src/java/org/jnativehook/mouse/NativeMouseInputAdapter.java
@@ -21,28 +21,8 @@ package org.jnativehook.mouse;
  * Adapter implementation of the NativeMouseInputListener interface.
  * The methods are empty so the super call is obsolete.
  * @author Johannes Boczek
- *
+ * @deprecated No need to extend this class, implement the {@code NativeMouseInputListener} interface instead
  * @since 2.1
  */
-public class NativeMouseInputAdapter implements NativeMouseInputListener {
-
-	public void nativeMouseClicked(NativeMouseEvent nativeEvent) {
-		// Do Nothing.
-	}
-
-	public void nativeMousePressed(NativeMouseEvent nativeEvent) {
-		// Do Nothing.
-	}
-
-	public void nativeMouseReleased(NativeMouseEvent nativeEvent) {
-		// Do Nothing.
-	}
-
-	public void nativeMouseDragged(NativeMouseEvent nativeEvent) {
-		// Do Nothing.
-	}
-
-	public void nativeMouseMoved(NativeMouseEvent nativeEvent) {
-		// Do Nothing.
-	}
-}
+@Deprecated
+public class NativeMouseInputAdapter implements NativeMouseInputListener {}

--- a/src/java/org/jnativehook/mouse/NativeMouseInputListener.java
+++ b/src/java/org/jnativehook/mouse/NativeMouseInputListener.java
@@ -27,6 +27,4 @@ package org.jnativehook.mouse;
  *
  * @see NativeMouseEvent
  */
-public interface NativeMouseInputListener extends NativeMouseListener, NativeMouseMotionListener {
-
-}
+public interface NativeMouseInputListener extends NativeMouseListener, NativeMouseMotionListener {}

--- a/src/java/org/jnativehook/mouse/NativeMouseListener.java
+++ b/src/java/org/jnativehook/mouse/NativeMouseListener.java
@@ -46,20 +46,19 @@ public interface NativeMouseListener extends EventListener {
 	 *
 	 * @param nativeEvent the native mouse event.
 	 */
-	public void nativeMouseClicked(NativeMouseEvent nativeEvent);
+	default void nativeMouseClicked(NativeMouseEvent nativeEvent) {}
 
 	/**
 	 * Invoked when a mouse button has been pressed
 	 *
 	 * @param nativeEvent the native mouse event.
 	 */
-	public void nativeMousePressed(NativeMouseEvent nativeEvent);
+	default void nativeMousePressed(NativeMouseEvent nativeEvent) {}
 
 	/**
 	 * Invoked when a mouse button has been released
 	 *
 	 * @param nativeEvent the native mouse event.
 	 */
-	public void nativeMouseReleased(NativeMouseEvent nativeEvent);
+	default void nativeMouseReleased(NativeMouseEvent nativeEvent) {}
 }
-

--- a/src/java/org/jnativehook/mouse/NativeMouseMotionAdapter.java
+++ b/src/java/org/jnativehook/mouse/NativeMouseMotionAdapter.java
@@ -21,15 +21,7 @@ package org.jnativehook.mouse;
  * Adapter implementation of the NativeMouseMotionListener interface.
  * The methods are empty so the super call is obsolete.
  * @author Johannes Boczek
- *
+ * @deprecated No need to extend this class, implement the {@code NativeMouseMotionListener} interface instead
  */
-public class NativeMouseMotionAdapter implements NativeMouseMotionListener {
-
-	public void nativeMouseDragged(NativeMouseEvent nativeEvent) {
-		// Do Nothing.
-	}
-
-	public void nativeMouseMoved(NativeMouseEvent nativeEvent) {
-		// Do Nothing.
-	}
-}
+@Deprecated
+public class NativeMouseMotionAdapter implements NativeMouseMotionListener {}

--- a/src/java/org/jnativehook/mouse/NativeMouseMotionListener.java
+++ b/src/java/org/jnativehook/mouse/NativeMouseMotionListener.java
@@ -45,7 +45,7 @@ public interface NativeMouseMotionListener extends EventListener {
 	 *
 	 * @param nativeEvent the native mouse event.
 	 */
-	public void nativeMouseMoved(NativeMouseEvent nativeEvent);
+	default void nativeMouseMoved(NativeMouseEvent nativeEvent) {}
 
 
 	/**
@@ -55,5 +55,5 @@ public interface NativeMouseMotionListener extends EventListener {
 	 *
 	 * @since 1.1
 	 */
-	public void nativeMouseDragged(NativeMouseEvent nativeEvent);
+	default void nativeMouseDragged(NativeMouseEvent nativeEvent) {}
 }

--- a/src/java/org/jnativehook/mouse/NativeMouseWheelAdapter.java
+++ b/src/java/org/jnativehook/mouse/NativeMouseWheelAdapter.java
@@ -16,10 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package org.jnativehook.mouse;
-
-public class NativeMouseWheelAdapter implements NativeMouseWheelListener {
-
-	public void nativeMouseWheelMoved(NativeMouseWheelEvent nativeEvent) {
-		// Do Nothing.
-	}
-}
+/**
+ * @deprecated No need to extend this class, implement the {@code NativeMouseWheelListener} interface instead
+ */
+@Deprecated
+public class NativeMouseWheelAdapter implements NativeMouseWheelListener {}

--- a/src/java/org/jnativehook/mouse/NativeMouseWheelListener.java
+++ b/src/java/org/jnativehook/mouse/NativeMouseWheelListener.java
@@ -46,5 +46,5 @@ public interface NativeMouseWheelListener extends EventListener {
 	 *
 	 * @param nativeEvent the native mouse wheel event.
 	 */
-	public void nativeMouseWheelMoved(NativeMouseWheelEvent nativeEvent);
+	default void nativeMouseWheelMoved(NativeMouseWheelEvent nativeEvent) {}
 }

--- a/src/java/org/jnativehook/mouse/SwingMouseAdapter.java
+++ b/src/java/org/jnativehook/mouse/SwingMouseAdapter.java
@@ -30,34 +30,42 @@ import java.awt.event.MouseListener;
  */
 public class SwingMouseAdapter extends AbstractSwingInputAdapter implements NativeMouseListener, MouseListener {
 
+	@Override
 	public void nativeMouseClicked(NativeMouseEvent nativeEvent) {
 		this.mouseClicked(this.getJavaKeyEvent(nativeEvent));
 	}
 
+	@Override
 	public void nativeMousePressed(NativeMouseEvent nativeEvent) {
 		this.mousePressed(this.getJavaKeyEvent(nativeEvent));
 	}
 
+	@Override
 	public void nativeMouseReleased(NativeMouseEvent nativeEvent) {
 		this.mouseReleased(this.getJavaKeyEvent(nativeEvent));
 	}
 
+	@Override
 	public void mouseClicked(MouseEvent mouseEvent) {
 		// Do Nothing.
 	}
 
+	@Override
 	public void mousePressed(MouseEvent mouseEvent) {
 		// Do Nothing.
 	}
 
+	@Override
 	public void mouseReleased(MouseEvent mouseEvent) {
 		// Do Nothing.
 	}
 
+	@Override
 	public void mouseEntered(MouseEvent mouseEvent) {
 		// Do Nothing.
 	}
 
+	@Override
 	public void mouseExited(MouseEvent mouseEvent) {
 		// Do Nothing.
 	}

--- a/src/java/org/jnativehook/mouse/SwingMouseWheelAdapter.java
+++ b/src/java/org/jnativehook/mouse/SwingMouseWheelAdapter.java
@@ -28,10 +28,12 @@ import java.awt.event.MouseWheelListener;
  */
 public class SwingMouseWheelAdapter extends SwingMouseAdapter implements NativeMouseWheelListener, MouseWheelListener {
 
+	@Override
 	public void nativeMouseWheelMoved(NativeMouseWheelEvent nativeEvent) {
 		this.mouseWheelMoved(this.getJavaMouseWheelEvent(nativeEvent));
 	}
 
+	@Override
 	public void mouseWheelMoved(MouseWheelEvent mouseWheelEvent) {
 		// Do Nothing.
 	}


### PR DESCRIPTION
Deprecate listener adapter classes, add default implementations for listener classes, add some missing overrides. Marked adapter classes as deprecated because they're not needed anymore.