### PR TITLE
Make module dependencies transitive

### DIFF
--- a/src/java/module-info.java
+++ b/src/java/module-info.java
@@ -4,6 +4,6 @@ module org.jnativehook {
 	exports org.jnativehook.keyboard;
 	exports org.jnativehook.mouse;
 
-	requires java.desktop;
-	requires java.logging;
+	requires transitive java.desktop;
+	requires transitive java.logging;
 }


### PR DESCRIPTION
Make the "desktop" and "logging" module dependencies transitive, so that no one has to add them to their own module descriptors. Alternative is to not make them transitive (like before), but then if anyone forgets about them apps gonna crash as soon as they call into the GlobalScreen class.