### PR TITLE
Replace deprecated Class.newInstance call with doc suggested replacement

### DIFF
--- a/src/java/org/jnativehook/GlobalScreen.java
+++ b/src/java/org/jnativehook/GlobalScreen.java
@@ -79,7 +79,7 @@ public class GlobalScreen {
 
 			try {
 				// Use the specified class to locator the native library.
-				NativeLibraryLocator locator = Class.forName(libLoader).asSubclass(NativeLibraryLocator.class).newInstance();
+				NativeLibraryLocator locator = Class.forName(libLoader).asSubclass(NativeLibraryLocator.class).getDeclaredConstructor().newInstance();
 
 				Iterator<File> libs = locator.getLibraries();
 				while (libs.hasNext()) {


### PR DESCRIPTION
- The method Class.newInstance was deprecated in Java 9
- Replacement was mentioned in the docs.: Class.getDeclaredConstructor().newInstance()

"The call clazz.newInstance() can be replaced by clazz.getDeclaredConstructor().newInstance()"