### PR TITLE
2.1 - Fix of native events property when values

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN emerge -1vuDN world
 
 # Setup the new gcc and binutils
 RUN gcc-config x86_64-pc-linux-gnu-9.2.0
-RUN binutils-config --linker ld.gold
+RUN LDFLAGS=-fuse-ld=gold LD=${CHOST}-ld.gold
 RUN . /etc/profile
 
 # We need to install git so that we can sync our custom apple overlay
@@ -51,7 +51,7 @@ RUN emerge -vu crossdev
 
 # Install Java via IcedTea
 RUN emerge -vu icedtea
-RUN emerge -vu ant
+RUN emerge -vu ant-core
 RUN eselect java-vm set system icedtea-8
 
 # Get the Windows JNI headers from AdoptOpenJDK
@@ -79,7 +79,7 @@ RUN emerge -vu libxcb
 #RUN i686-cc-linux-gnu-emerge -uv libXtst
 #RUN i686-cc-linux-gnu-emerge -uv libXinerama
 #RUN i686-cc-linux-gnu-emerge -uv libxkbcommon
-#RUN i686-cc-linux-gnu-emerge -uv libxkbfile 
+#RUN i686-cc-linux-gnu-emerge -uv libxkbfile
 #RUN i686-cc-linux-gnu-emerge -uv libxcb
 #RUN gcc-config i686-cc-linux-gnu-9.2.0
 

--- a/src/jni/jni_EventDispatcher.c
+++ b/src/jni/jni_EventDispatcher.c
@@ -195,7 +195,7 @@ void jni_EventDispatcher(uiohook_event * const event) {
 
 		if (NativeInputEvent_obj != NULL) {
 			// Set the private when field to the native event time.
-			(*env)->SetShortField(
+			(*env)->SetLongField(
 					env,
 					NativeInputEvent_obj,
 					org_jnativehook_NativeInputEvent->when,

--- a/src/test/org/jnativehook/EventsPropertiesTestManual.java
+++ b/src/test/org/jnativehook/EventsPropertiesTestManual.java
@@ -1,0 +1,180 @@
+package org.jnativehook;
+
+import java.util.Scanner;
+import java.util.concurrent.Executors;
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.jnativehook.keyboard.NativeKeyEvent;
+import org.jnativehook.keyboard.NativeKeyListener;
+import org.jnativehook.mouse.NativeMouseEvent;
+import org.jnativehook.mouse.NativeMouseInputListener;
+import org.jnativehook.mouse.NativeMouseWheelEvent;
+import org.jnativehook.mouse.NativeMouseWheelListener;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class EventsPropertiesTestManual
+		implements NativeKeyListener, NativeMouseInputListener, NativeMouseWheelListener {
+
+	private static final Logger LOG;
+	static {
+		LOG = Logger.getLogger(EventsPropertiesTestManual.class.getCanonicalName());
+		LOG.setUseParentHandlers(false);
+		LOG.setLevel(Level.ALL);
+		ConsoleHandler handler = new ConsoleHandler();
+		handler.setLevel(Level.ALL);
+		LOG.addHandler(handler);
+	}
+
+	private static final NativeSystem.Family OS = NativeSystem.getFamily();
+
+	// Warning if dispatch delay is more than this value
+	private static final long MAX_DISPATH_DELLAY_MS = 100;
+
+	private boolean active;
+	private AssertionError assertionError;
+
+	private NativeInputEvent prevEvent;
+	private long initialWhen;
+	private long initialMilis;
+
+	@BeforeClass
+	public static void beforeClass() throws NativeHookException {
+		GlobalScreen.registerNativeHook();
+	}
+
+	@AfterClass
+	public static void afterClass() throws NativeHookException {
+		GlobalScreen.unregisterNativeHook();
+	}
+
+	@Test
+	public void testEventsTime() throws InterruptedException {
+		try {
+			active = true;
+			GlobalScreen.addNativeMouseWheelListener(this);
+			GlobalScreen.addNativeMouseMotionListener(this);
+			GlobalScreen.addNativeMouseListener(this);
+			GlobalScreen.addNativeKeyListener(this);
+			Executors.newSingleThreadExecutor().execute(new Runnable() {
+
+				public void run() {
+					// Allow tester stop testing by pressing <EENTER> in console.
+					System.out.println( // NOSONAR (Using system console output here)
+							"Press <ENTER> to stop testing native events properties...");
+					final Scanner scanner = new Scanner(System.in);
+					scanner.nextLine();
+					scanner.close();
+					active = false;
+				}
+			});
+			while (active) {
+				// Simple way to wait for error or stop by user
+				Thread.sleep(250);
+			}
+			if (assertionError != null) {
+				throw assertionError;
+			}
+		} finally {
+			active = false;
+			GlobalScreen.removeNativeMouseWheelListener(this);
+			GlobalScreen.removeNativeMouseMotionListener(this);
+			GlobalScreen.removeNativeMouseListener(this);
+			GlobalScreen.removeNativeKeyListener(this);
+		}
+	}
+
+	// synchronized to prevent process event in wrong order
+	private synchronized void validateEventTime(final NativeInputEvent e) {
+		if (!active) {
+			// Prevent from events validation when testing is stopping
+			return;
+		}
+		if (prevEvent != null) {
+			final long milis = System.currentTimeMillis();
+			final long when = e.getWhen();
+			if (prevEvent.getWhen() > when || 
+					// when <= 0 usually means property "when" wasn't initialized
+					when <= 0) {
+// FIXME Error still was happening on Windows eventually/randomly.
+// Try figure out cause of it. 
+// Usually error was happening when different type of events was compared, 
+// f.e., mouse wheel and mouse move was compared by timestamp.
+// java.lang.AssertionError: Previous event time is higher than current event time: 58078484 > 58078468
+//   prevEvent = id=2503,when=58078484,mask=0,modifiers=NATIVE_MOUSE_MOVED,(1051,310),button=0,clickCount=0
+//   event = id=2505,when=58078468,mask=0,modifiers=NATIVE_MOUSE_WHEEL,(1051,310),button=0,clickCount=1,
+//	  scrollType=WHEEL_UNIT_SCROLL,scrollAmount=3,wheelRotation=0,wheelDirection=WHEEL_VERTICAL_DIRECTION
+				assertionError = new AssertionError(
+						"Previous event time is higher than current event time: "
+								+ prevEvent.getWhen() + " > " + when 
+								+ "\nprevEvent = " + prevEvent.paramString()
+								+ "\nevent = " + e.paramString());
+				active = false;
+			}
+			final double diffMilis;
+			if (NativeSystem.Family.DARWIN == OS) {
+				// On macOS native timestamp was in nanoseconds.
+				// Tested using: 
+				// * macOS 10.15.3 Catalina.
+				diffMilis = Math.abs((milis - initialMilis) - (when - initialWhen) / 1000000.0);
+			} else {
+				// On Windows and Linux native timestamp was in miliseconds.
+				// Tested using: 
+				// * Windows 10 VM macOS host (using Parallels Desktop).
+				// * Ubuntu 18.04 VM macOS host (using Parallels Desktop).
+				diffMilis = Math.abs((milis - initialMilis) - (when - initialWhen));
+			}
+
+			if (LOG.isLoggable(Level.FINEST)) {
+				LOG.log(Level.FINEST, "Time differnce: {0} [ms]", diffMilis);
+			}
+			if (diffMilis > MAX_DISPATH_DELLAY_MS) {
+				LOG.log(Level.WARNING, "Time differnce is > {0} ms: {1}",
+						new Object[] {MAX_DISPATH_DELLAY_MS, diffMilis});
+			}
+		} else {
+			initialWhen = e.getWhen();
+			initialMilis = System.currentTimeMillis();
+		}
+		prevEvent = e;
+	}
+
+	public void nativeMouseClicked(NativeMouseEvent e) {
+		validateEventTime(e);
+	}
+
+	public void nativeMousePressed(NativeMouseEvent e) {
+		validateEventTime(e);
+	}
+
+	public void nativeMouseReleased(NativeMouseEvent e) {
+		validateEventTime(e);
+	}
+
+	public void nativeMouseMoved(NativeMouseEvent e) {
+		validateEventTime(e);
+	}
+
+	public void nativeMouseDragged(NativeMouseEvent e) {
+		validateEventTime(e);
+	}
+
+	public void nativeMouseWheelMoved(NativeMouseWheelEvent e) {
+		validateEventTime(e);
+	}
+
+	public void nativeKeyTyped(NativeKeyEvent e) {
+		validateEventTime(e);
+	}
+
+	public void nativeKeyPressed(NativeKeyEvent e) {
+		validateEventTime(e);
+	}
+
+	public void nativeKeyReleased(NativeKeyEvent e) {
+		validateEventTime(e);
+	}
+}

--- a/src/test/org/jnativehook/GlobalScreenTest.java
+++ b/src/test/org/jnativehook/GlobalScreenTest.java
@@ -446,7 +446,7 @@ public class GlobalScreenTest {
 				NativeKeyEvent.KEY_LOCATION_STANDARD);
 
 		synchronized (keyListener) {
-			GlobalScreen.dispatchEvent(keyEvent);
+			GlobalScreen.postNativeEvent(keyEvent);
 			keyListener.wait(3000);
 			assertEquals(keyEvent, keyListener.getLastEvent());
 		}
@@ -462,7 +462,7 @@ public class GlobalScreenTest {
 				NativeMouseEvent.BUTTON1);
 
 		synchronized (mouseListener) {
-			GlobalScreen.dispatchEvent(mouseEvent);
+			GlobalScreen.postNativeEvent(mouseEvent);
 			mouseListener.wait(3000);
 			assertEquals(mouseEvent, mouseListener.getLastEvent());
 		}
@@ -479,7 +479,7 @@ public class GlobalScreenTest {
 				-1);	// Wheel Rotation
 
 		synchronized (wheelListener) {
-			GlobalScreen.dispatchEvent(wheelEvent);
+			GlobalScreen.postNativeEvent(wheelEvent);
 			wheelListener.wait(3000);
 			assertEquals(wheelEvent, wheelListener.getLastEvent());
 		}
@@ -514,7 +514,7 @@ public class GlobalScreenTest {
 				NativeKeyEvent.KEY_LOCATION_UNKNOWN);
 
 		synchronized (listener) {
-			GlobalScreen.dispatchEvent(event);
+			GlobalScreen.postNativeEvent(event);
 			listener.wait(3000);
 			assertEquals(event, listener.getLastEvent());
 		}
@@ -543,7 +543,7 @@ public class GlobalScreenTest {
 				NativeMouseEvent.BUTTON1);
 
 		synchronized (listener) {
-			GlobalScreen.dispatchEvent(event);
+			GlobalScreen.postNativeEvent(event);
 			listener.wait(3000);
 			assertEquals(event, listener.getLastEvent());
 		}
@@ -574,7 +574,7 @@ public class GlobalScreenTest {
 				-1);	// Wheel Rotation
 
 		synchronized (listener) {
-			GlobalScreen.dispatchEvent(event);
+			GlobalScreen.postNativeEvent(event);
 			listener.wait(3000);
 			assertEquals(event, listener.getLastEvent());
 		}


### PR DESCRIPTION
#281 Native events has wrong timestamp (property when) value
https://github.com/kwhat/jnativehook/issues/281

  * Changed SetShortField to SetLongField. Timestamp value is jlong not
jint. It was causing property when oscillating by integer range overflow.
  * Created manual test EventsPropertiesTestManual.java for this value
  * Fixed compilation of GlobalScreenTest.java
