### PR TITLE
Listener class refactorings for java 8

### DIFF
--- a/src/main/java/org/jnativehook/keyboard/NativeKeyAdapter.java
+++ b/src/main/java/org/jnativehook/keyboard/NativeKeyAdapter.java
@@ -21,21 +21,9 @@ package org.jnativehook.keyboard;
  * Adapter implementation of the NativeKeyListener interface. The methods are empty so the super
  * call is obsolete.
  *
+ * @deprecated No need to extend this class, implement the {@code NativeKeyListener} interface instead
  * @author Johannes Boczek
  * @since 2.1
  */
-public class NativeKeyAdapter implements NativeKeyListener {
-
-    public void nativeKeyTyped(NativeKeyEvent nativeEvent) {
-        // Do Nothing.
-    }
-
-    public void nativeKeyPressed(NativeKeyEvent nativeEvent) {
-        // Do Nothing.
-    }
-
-    public void nativeKeyReleased(NativeKeyEvent nativeEvent) {
-        // Do Nothing.
-    }
-
-}
+@Deprecated
+public class NativeKeyAdapter implements NativeKeyListener {}

--- a/src/main/java/org/jnativehook/keyboard/NativeKeyListener.java
+++ b/src/main/java/org/jnativehook/keyboard/NativeKeyListener.java
@@ -23,7 +23,7 @@ import org.jnativehook.GlobalScreen;
 /**
  * The listener interface for receiving global <code>NativeKeyEvents</code>.
  * <p>
- * 
+ *
  * The class that is interested in processing a <code>NativeKeyEvent</code> implements this
  * interface, and the object created with that class is registered with the
  * <code>GlobalScreen</code> using the {@link GlobalScreen#addNativeKeyListener(NativeKeyListener)}
@@ -44,19 +44,19 @@ public interface NativeKeyListener extends EventListener {
      * @param nativeEvent the native key event.
      * @since 1.1
      */
-    public void nativeKeyTyped(NativeKeyEvent nativeEvent);
+    default void nativeKeyTyped(NativeKeyEvent nativeEvent) {}
 
     /**
      * Invoked when a key has been pressed.
      *
      * @param nativeEvent the native key event.
      */
-    public void nativeKeyPressed(NativeKeyEvent nativeEvent);
+    default void nativeKeyPressed(NativeKeyEvent nativeEvent) {}
 
     /**
      * Invoked when a key has been released.
      *
      * @param nativeEvent the native key event.
      */
-    public void nativeKeyReleased(NativeKeyEvent nativeEvent);
+    default void nativeKeyReleased(NativeKeyEvent nativeEvent) {}
 }

--- a/src/main/java/org/jnativehook/keyboard/SwingKeyAdapter.java
+++ b/src/main/java/org/jnativehook/keyboard/SwingKeyAdapter.java
@@ -29,29 +29,29 @@ import org.jnativehook.AbstractSwingInputAdapter;
  */
 public class SwingKeyAdapter extends AbstractSwingInputAdapter implements NativeKeyListener, KeyListener {
 
+    @Override
     public void nativeKeyTyped(NativeKeyEvent nativeEvent) {
         this.keyTyped(this.getJavaKeyEvent(nativeEvent));
     }
 
+    @Override
     public void nativeKeyPressed(NativeKeyEvent nativeEvent) {
         this.keyPressed(this.getJavaKeyEvent(nativeEvent));
     }
 
+    @Override
     public void nativeKeyReleased(NativeKeyEvent nativeEvent) {
         this.keyReleased(this.getJavaKeyEvent(nativeEvent));
     }
 
-    public void keyTyped(KeyEvent keyEvent) {
-        // Do Nothing.
-    }
+    @Override
+    public void keyTyped(KeyEvent keyEvent) {}
 
-    public void keyPressed(KeyEvent keyEvent) {
-        // Do Nothing.
-    }
+    @Override
+    public void keyPressed(KeyEvent keyEvent) {}
 
-    public void keyReleased(KeyEvent keyEvent) {
-        // Do Nothing.
-    }
+    @Override
+    public void keyReleased(KeyEvent keyEvent) {}
 
     protected KeyEvent getJavaKeyEvent(NativeKeyEvent nativeEvent) {
         int keyLocation = KeyEvent.KEY_LOCATION_UNKNOWN;

--- a/src/main/java/org/jnativehook/mouse/NativeMouseAdapter.java
+++ b/src/main/java/org/jnativehook/mouse/NativeMouseAdapter.java
@@ -21,20 +21,8 @@ package org.jnativehook.mouse;
  * Adapter implementation of the NativeMouseListener interface. The methods are empty so the super
  * call is obsolete.
  *
+ * @deprecated No need to extend this class, implement the {@code NativeMouseListener} interface instead
  * @author Johannes Boczek
  */
-public class NativeMouseAdapter implements NativeMouseListener {
-
-    public void nativeMouseClicked(NativeMouseEvent nativeEvent) {
-        // Do Nothing.
-    }
-
-    public void nativeMousePressed(NativeMouseEvent nativeEvent) {
-        // Do Nothing.
-    }
-
-    public void nativeMouseReleased(NativeMouseEvent nativeEvent) {
-        // Do Nothing.
-    }
-
-}
+@Deprecated
+public class NativeMouseAdapter implements NativeMouseListener {}

--- a/src/main/java/org/jnativehook/mouse/NativeMouseInputAdapter.java
+++ b/src/main/java/org/jnativehook/mouse/NativeMouseInputAdapter.java
@@ -21,28 +21,9 @@ package org.jnativehook.mouse;
  * Adapter implementation of the NativeMouseInputListener interface. The methods are empty so the
  * super call is obsolete.
  *
+ * @deprecated No need to extend this class, implement the {@code NativeMouseInputListener} interface instead
  * @author Johannes Boczek
  * @since 2.1
  */
-public class NativeMouseInputAdapter implements NativeMouseInputListener {
-
-    public void nativeMouseClicked(NativeMouseEvent nativeEvent) {
-        // Do Nothing.
-    }
-
-    public void nativeMousePressed(NativeMouseEvent nativeEvent) {
-        // Do Nothing.
-    }
-
-    public void nativeMouseReleased(NativeMouseEvent nativeEvent) {
-        // Do Nothing.
-    }
-
-    public void nativeMouseDragged(NativeMouseEvent nativeEvent) {
-        // Do Nothing.
-    }
-
-    public void nativeMouseMoved(NativeMouseEvent nativeEvent) {
-        // Do Nothing.
-    }
-}
+@Deprecated
+public class NativeMouseInputAdapter implements NativeMouseInputListener {}

--- a/src/main/java/org/jnativehook/mouse/NativeMouseInputListener.java
+++ b/src/main/java/org/jnativehook/mouse/NativeMouseInputListener.java
@@ -26,6 +26,4 @@ package org.jnativehook.mouse;
  * @since 1.0
  * @see NativeMouseEvent
  */
-public interface NativeMouseInputListener extends NativeMouseListener, NativeMouseMotionListener {
-
-}
+public interface NativeMouseInputListener extends NativeMouseListener, NativeMouseMotionListener {}

--- a/src/main/java/org/jnativehook/mouse/NativeMouseListener.java
+++ b/src/main/java/org/jnativehook/mouse/NativeMouseListener.java
@@ -42,20 +42,19 @@ public interface NativeMouseListener extends EventListener {
      *
      * @param nativeEvent the native mouse event.
      */
-    public void nativeMouseClicked(NativeMouseEvent nativeEvent);
+    default void nativeMouseClicked(NativeMouseEvent nativeEvent) {}
 
     /**
      * Invoked when a mouse button has been pressed
      *
      * @param nativeEvent the native mouse event.
      */
-    public void nativeMousePressed(NativeMouseEvent nativeEvent);
+    default void nativeMousePressed(NativeMouseEvent nativeEvent) {}
 
     /**
      * Invoked when a mouse button has been released
      *
      * @param nativeEvent the native mouse event.
      */
-    public void nativeMouseReleased(NativeMouseEvent nativeEvent);
+    default void nativeMouseReleased(NativeMouseEvent nativeEvent) {}
 }
-

--- a/src/main/java/org/jnativehook/mouse/NativeMouseMotionAdapter.java
+++ b/src/main/java/org/jnativehook/mouse/NativeMouseMotionAdapter.java
@@ -21,15 +21,8 @@ package org.jnativehook.mouse;
  * Adapter implementation of the NativeMouseMotionListener interface. The methods are empty so the
  * super call is obsolete.
  *
+ * @deprecated No need to extend this class, implement the {@code NativeMouseMotionListener} interface instead
  * @author Johannes Boczek
  */
-public class NativeMouseMotionAdapter implements NativeMouseMotionListener {
-
-    public void nativeMouseDragged(NativeMouseEvent nativeEvent) {
-        // Do Nothing.
-    }
-
-    public void nativeMouseMoved(NativeMouseEvent nativeEvent) {
-        // Do Nothing.
-    }
-}
+@Deprecated
+public class NativeMouseMotionAdapter implements NativeMouseMotionListener {}

--- a/src/main/java/org/jnativehook/mouse/NativeMouseMotionListener.java
+++ b/src/main/java/org/jnativehook/mouse/NativeMouseMotionListener.java
@@ -42,8 +42,7 @@ public interface NativeMouseMotionListener extends EventListener {
      *
      * @param nativeEvent the native mouse event.
      */
-    public void nativeMouseMoved(NativeMouseEvent nativeEvent);
-
+    default void nativeMouseMoved(NativeMouseEvent nativeEvent) {}
 
     /**
      * Invoked when the mouse has been moved while a button is depressed.
@@ -51,5 +50,5 @@ public interface NativeMouseMotionListener extends EventListener {
      * @param nativeEvent the native mouse event
      * @since 1.1
      */
-    public void nativeMouseDragged(NativeMouseEvent nativeEvent);
+    default void nativeMouseDragged(NativeMouseEvent nativeEvent) {}
 }

--- a/src/main/java/org/jnativehook/mouse/NativeMouseWheelAdapter.java
+++ b/src/main/java/org/jnativehook/mouse/NativeMouseWheelAdapter.java
@@ -17,9 +17,8 @@
  */
 package org.jnativehook.mouse;
 
-public class NativeMouseWheelAdapter implements NativeMouseWheelListener {
-
-    public void nativeMouseWheelMoved(NativeMouseWheelEvent nativeEvent) {
-        // Do Nothing.
-    }
-}
+/**
+ * @deprecated No need to extend this class, implement the {@code NativeMouseWheelListener} interface instead
+ */
+@Deprecated
+public class NativeMouseWheelAdapter implements NativeMouseWheelListener {}

--- a/src/main/java/org/jnativehook/mouse/NativeMouseWheelListener.java
+++ b/src/main/java/org/jnativehook/mouse/NativeMouseWheelListener.java
@@ -41,5 +41,5 @@ public interface NativeMouseWheelListener extends EventListener {
      *
      * @param nativeEvent the native mouse wheel event.
      */
-    public void nativeMouseWheelMoved(NativeMouseWheelEvent nativeEvent);
+    default void nativeMouseWheelMoved(NativeMouseWheelEvent nativeEvent) {}
 }

--- a/src/main/java/org/jnativehook/mouse/SwingMouseAdapter.java
+++ b/src/main/java/org/jnativehook/mouse/SwingMouseAdapter.java
@@ -29,37 +29,35 @@ import org.jnativehook.AbstractSwingInputAdapter;
  */
 public class SwingMouseAdapter extends AbstractSwingInputAdapter implements NativeMouseListener, MouseListener {
 
+    @Override
     public void nativeMouseClicked(NativeMouseEvent nativeEvent) {
         this.mouseClicked(this.getJavaKeyEvent(nativeEvent));
     }
 
+    @Override
     public void nativeMousePressed(NativeMouseEvent nativeEvent) {
         this.mousePressed(this.getJavaKeyEvent(nativeEvent));
     }
 
+    @Override
     public void nativeMouseReleased(NativeMouseEvent nativeEvent) {
         this.mouseReleased(this.getJavaKeyEvent(nativeEvent));
     }
 
-    public void mouseClicked(MouseEvent mouseEvent) {
-        // Do Nothing.
-    }
+    @Override
+    public void mouseClicked(MouseEvent mouseEvent) {}
 
-    public void mousePressed(MouseEvent mouseEvent) {
-        // Do Nothing.
-    }
+    @Override
+    public void mousePressed(MouseEvent mouseEvent) {}
 
-    public void mouseReleased(MouseEvent mouseEvent) {
-        // Do Nothing.
-    }
+    @Override
+    public void mouseReleased(MouseEvent mouseEvent) {}
 
-    public void mouseEntered(MouseEvent mouseEvent) {
-        // Do Nothing.
-    }
+    @Override
+    public void mouseEntered(MouseEvent mouseEvent) {}
 
-    public void mouseExited(MouseEvent mouseEvent) {
-        // Do Nothing.
-    }
+    @Override
+    public void mouseExited(MouseEvent mouseEvent) {}
 
     protected MouseEvent getJavaKeyEvent(NativeMouseEvent nativeEvent) {
         return new MouseEvent(

--- a/src/main/java/org/jnativehook/mouse/SwingMouseWheelAdapter.java
+++ b/src/main/java/org/jnativehook/mouse/SwingMouseWheelAdapter.java
@@ -29,13 +29,13 @@ import java.awt.event.MouseWheelListener;
 public class SwingMouseWheelAdapter extends SwingMouseAdapter implements NativeMouseWheelListener,
     MouseWheelListener {
 
+    @Override
     public void nativeMouseWheelMoved(NativeMouseWheelEvent nativeEvent) {
         this.mouseWheelMoved(this.getJavaMouseWheelEvent(nativeEvent));
     }
 
-    public void mouseWheelMoved(MouseWheelEvent mouseWheelEvent) {
-        // Do Nothing.
-    }
+    @Override
+    public void mouseWheelMoved(MouseWheelEvent mouseWheelEvent) {}
 
     protected MouseWheelEvent getJavaMouseWheelEvent(NativeMouseWheelEvent nativeEvent) {
         int scrollType = MouseWheelEvent.WHEEL_UNIT_SCROLL;


### PR DESCRIPTION
Deprecate listener adapter classes, add default implementations for listener classes, add some missing overrides. Marked adapter classes as deprecated because they're not needed anymore.
(same as #245, but had to recreate because my original fork was deleted)